### PR TITLE
Programmatic skip

### DIFF
--- a/Gauge.CSharp.Lib/Attribute/Exceptions.cs
+++ b/Gauge.CSharp.Lib/Attribute/Exceptions.cs
@@ -1,0 +1,22 @@
+/*----------------------------------------------------------------
+ *  Copyright (c) ThoughtWorks, Inc.
+ *  Licensed under the Apache License, Version 2.0
+ *  See LICENSE.txt in the project root for license information.
+ *----------------------------------------------------------------*/
+using System;
+
+namespace Gauge.CSharp.Lib.Attribute
+{
+    [Serializable]
+    public class SkipScenarioException : Exception
+    {
+        public SkipScenarioException() : base() { }
+
+        public SkipScenarioException(string message) : base(message) { }
+
+        public SkipScenarioException(string message, Exception innerException) : base(message, innerException) { }
+
+        protected SkipScenarioException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+
+}

--- a/Gauge.CSharp.Lib/Attribute/Exceptions.cs
+++ b/Gauge.CSharp.Lib/Attribute/Exceptions.cs
@@ -12,9 +12,13 @@ namespace Gauge.CSharp.Lib.Attribute
     {
         public SkipScenarioException() : base() { }
 
-        public SkipScenarioException(string message) : base(message) { }
+        public SkipScenarioException(string message) : base(message) { 
+            GaugeMessages.WriteMessage(message);
+        }
 
-        public SkipScenarioException(string message, Exception innerException) : base(message, innerException) { }
+        public SkipScenarioException(string message, Exception innerException) : base(message, innerException) { 
+            GaugeMessages.WriteMessage(message);
+        }
 
         protected SkipScenarioException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }

--- a/Gauge.CSharp.Lib/Gauge.CSharp.Lib.csproj
+++ b/Gauge.CSharp.Lib/Gauge.CSharp.Lib.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>CSharp bindings for Gauge. Write CSharp step implementation for Gauge specs. https://gauge.org</Description>
-    <Version>0.10.1</Version>
-    <AssemblyVersion>0.10.1.0</AssemblyVersion>
-    <FileVersion>0.10.1.0</FileVersion>
+    <Version>0.10.2</Version>
+    <AssemblyVersion>0.10.2.0</AssemblyVersion>
+    <FileVersion>0.10.2.0</FileVersion>
     <Authors>getgauge</Authors>
     <Company>ThoughtWorks Inc.</Company>
     <Copyright>Copyright © ThoughtWorks Inc. 2018</Copyright>

--- a/Gauge.CSharp.Lib/ScenarioDataStore.cs
+++ b/Gauge.CSharp.Lib/ScenarioDataStore.cs
@@ -26,5 +26,6 @@ namespace Gauge.CSharp.Lib
         {
             store.Clear();
         }
+        internal bool SkipScenario = false;
     }
 }

--- a/Gauge.CSharp.Lib/ScenarioDataStore.cs
+++ b/Gauge.CSharp.Lib/ScenarioDataStore.cs
@@ -26,6 +26,5 @@ namespace Gauge.CSharp.Lib
         {
             store.Clear();
         }
-        internal bool SkipScenario = false;
     }
 }


### PR DESCRIPTION
Add SkipScenarioException to be used for programmatically skipping remaining scenario execution.