### PR TITLE
Adding method to allow screenshots from the plugin with the datastores setup

### DIFF
--- a/Gauge.CSharp.Lib/Gauge.CSharp.Lib.csproj
+++ b/Gauge.CSharp.Lib/Gauge.CSharp.Lib.csproj
@@ -4,9 +4,9 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<Description>CSharp bindings for Gauge. Write CSharp step implementation for Gauge specs. https://gauge.org</Description>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>0.11.1</Version>
-		<AssemblyVersion>0.11.1.0</AssemblyVersion>
-		<FileVersion>0.11.1.0</FileVersion>
+		<Version>0.11.2</Version>
+		<AssemblyVersion>0.11.2.0</AssemblyVersion>
+		<FileVersion>0.11.2.0</FileVersion>
 		<Authors>getgauge</Authors>
 		<Company>ThoughtWorks Inc.</Company>
 		<Copyright>Copyright © ThoughtWorks Inc. 2018</Copyright>

--- a/Gauge.CSharp.Lib/GaugeScreenshots.cs
+++ b/Gauge.CSharp.Lib/GaugeScreenshots.cs
@@ -20,4 +20,27 @@ public static class GaugeScreenshots
     {
         ScreenshotFiles.Add(screenshotWriter.TakeScreenShot());
     }
+
+    public static void CaptureByStream(int streamId)
+    {
+        SetDataStores(streamId);
+        ScreenshotFiles.Add(screenshotWriter.TakeScreenShot());
+    }
+
+    private static void SetDataStores(int streamId)
+    {
+        var dataStore = DataStoreFactory.GetDataStoresByStream(streamId);
+        lock (SuiteDataStore.Store)
+        {
+            SuiteDataStore.Store.Value = DataStoreFactory.SuiteDataStore;
+        }
+        lock (SpecDataStore.Store)
+        {
+            SpecDataStore.Store.Value = dataStore.GetValueOrDefault(DataStoreType.Spec, null);
+        }
+        lock (ScenarioDataStore.Store)
+        {
+            ScenarioDataStore.Store.Value = dataStore.GetValueOrDefault(DataStoreType.Scenario, null);
+        }
+    }
 }


### PR DESCRIPTION
I will also be updating the plugin to call the new method. Steps and hooks should still call the Capture method, but when the Capture method is called from the plugin through reflection, the datastores would not be setup.