### PR TITLE
Definition of SkipScenarioException for scenario skip functionality

### DIFF
--- a/Gauge.CSharp.Lib/Gauge.CSharp.Lib.csproj
+++ b/Gauge.CSharp.Lib/Gauge.CSharp.Lib.csproj
@@ -4,9 +4,9 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<Description>CSharp bindings for Gauge. Write CSharp step implementation for Gauge specs. https://gauge.org</Description>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>0.11.2</Version>
-		<AssemblyVersion>0.11.2.0</AssemblyVersion>
-		<FileVersion>0.11.2.0</FileVersion>
+		<Version>0.11.3</Version>
+		<AssemblyVersion>0.11.3.0</AssemblyVersion>
+		<FileVersion>0.11.3.0</FileVersion>
 		<Authors>getgauge</Authors>
 		<Company>ThoughtWorks Inc.</Company>
 		<Copyright>Copyright © ThoughtWorks Inc. 2018</Copyright>

--- a/Gauge.CSharp.Lib/SkipScenarioException.cs
+++ b/Gauge.CSharp.Lib/SkipScenarioException.cs
@@ -3,7 +3,7 @@
  *  Licensed under the Apache License, Version 2.0
  *  See LICENSE.txt in the project root for license information.
  *----------------------------------------------------------------*/
-namespace Gauge.CSharp.Lib.Attribute;
+namespace Gauge.CSharp.Lib;
 
 [Serializable]
 public class SkipScenarioException : Exception


### PR DESCRIPTION
@sriv
This is a cosmetic change for the SkipScenarioException.
The SkipScenarioException definition is moved out from the Attribute namespace 